### PR TITLE
fix usage as an external package

### DIFF
--- a/bin/chart-valuation-service.js
+++ b/bin/chart-valuation-service.js
@@ -12,14 +12,6 @@ require('../src/generateChart')
     process.exitCode = 0
   })
   .catch((error) => {
-    if (console) {
-      // pretty-print the error
-      console.error(error)
-    } else {
-      process.stderr.write(
-        typeof error === 'string' || error instanceof Uint8Array ? error : `${error}`
-      )
-    }
-
+    process.stderr.write(error)
     process.exitCode = 1
   })

--- a/bin/chart-valuation-service.js
+++ b/bin/chart-valuation-service.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 require('ts-node').register({
+  project: require('path').resolve(__dirname, '..', 'tsconfig.json'), // setting the `project` allows to use this package as a typescript "binary"
   transpileOnly: true
 })
 
@@ -11,6 +12,14 @@ require('../src/generateChart')
     process.exitCode = 0
   })
   .catch((error) => {
-    process.stderr.write(error)
+    if (console) {
+      // pretty-print the error
+      console.error(error)
+    } else {
+      process.stderr.write(
+        typeof error === 'string' || error instanceof Uint8Array ? error : `${error}`
+      )
+    }
+
     process.exitCode = 1
   })


### PR DESCRIPTION
`moss` backend can not execute the project's "binary" due to invalid `typescript` compiler options provided, this PR fixes that by setting up the `project` property which points at the proper `tsconfig.json` file

